### PR TITLE
Fix: add return type for method getConfigTreeBuilder

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,7 +14,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 final class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('wopi');
 


### PR DESCRIPTION
This PR:

* [x] Fix ...
* [ ] Provide ...
* [ ] It breaks backward compatibility
* [ ] Has unit tests (phpspec)
* [ ] Has static analysis tests (psalm, phpstan)
* [ ] Has documentation
* [ ] Is an experimental thing

Follows #.
Related to #.
Fixes the missing return type required to be compliant with latest versions of Symfony.
